### PR TITLE
Update debug_stick.json

### DIFF
--- a/pack/items/debug_stick.json
+++ b/pack/items/debug_stick.json
@@ -14,6 +14,7 @@
 			"minecraft:icon": {
 				"texture": "stick"
 			},
+			"minecraft:hand_equipped": true,
 			"minecraft:display_name": {
 				"value": "§dDebug Stick§r"
 			},


### PR DESCRIPTION
Added "minecraft:hand_equipped" component. This makes the debug stick visually match the vanilla stick, besides the item glint